### PR TITLE
Top PyPI Packages: Use 30-days data, 365 is no longer available

### DIFF
--- a/plugins/typo_squatting_scan.py
+++ b/plugins/typo_squatting_scan.py
@@ -29,7 +29,7 @@ class Typo_Squatting_Protection(IPlugin):
 
         def _downloading_top_5000():
             inventory_raw = requests.get(
-                "https://hugovk.github.io/top-pypi-packages/top-pypi-packages-365-days.json"
+                "https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.json"
             )
             with open(
                 f"{plugin_location}/top5000_list.json", "w", encoding="utf-8"


### PR DESCRIPTION
I needed to remove the 365-day data from https://hugovk.github.io/top-pypi-packages/ because it was using more quota than available, so let's use the 30-day one instead.

Re: https://github.com/hugovk/top-pypi-packages/pull/21, https://github.com/hugovk/top-pypi-packages/pull/20, https://github.com/hugovk/top-pypi-packages/issues/19.
